### PR TITLE
Fix Highlight Problem

### DIFF
--- a/src/main/scala/amailp/intellij/robot/extensions/Annotator.scala
+++ b/src/main/scala/amailp/intellij/robot/extensions/Annotator.scala
@@ -11,7 +11,7 @@ class Annotator extends com.intellij.lang.annotation.Annotator {
   def annotate(element: PsiElement, holder: AnnotationHolder): Unit = {
 
     def highlightAs(attr: TextAttributesKey): Unit = {
-      holder.newSilentAnnotation(HighlightSeverity.INFORMATION).textAttributes(attr)
+      holder.newSilentAnnotation(HighlightSeverity.INFORMATION).textAttributes(attr).create()
     }
 
     element match {

--- a/src/test/scala/amailp/intellij/robot/extensions/AnnotatorTest.scala
+++ b/src/test/scala/amailp/intellij/robot/extensions/AnnotatorTest.scala
@@ -1,0 +1,15 @@
+package amailp.intellij.robot.extensions
+
+import amailp.intellij.robot.testFramework.RobotCodeInsightFixtureTestCase
+
+class AnnotatorTest extends RobotCodeInsightFixtureTestCase {
+
+  def testVariablesInAnnotator(): Unit = {
+    myFixture
+      .configureByFiles(
+          "complete.robot"
+      )
+
+    myFixture.checkHighlighting(false, true, false, true)
+  }
+}


### PR DESCRIPTION
There is an error with the versions 0.24 to the 0.26 not showing the highlight and the IDE gets in a loop analyzing the robot files.

this is the log of the error
#120 

@AmailP Please can you look at it! 🙏
and remade the plugin for IDE version 2020.3.4 🙇‍♂️
